### PR TITLE
fix overflow text of  storymap title cards & action cards an…

### DIFF
--- a/project-canvas/src/components/StoryMapView/Cards/ActionCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/ActionCard.tsx
@@ -1,4 +1,4 @@
-import { PaperProps, Text, TextInput } from "@mantine/core"
+import { PaperProps, Text, TextInput, Tooltip } from "@mantine/core"
 import { useHover } from "@mantine/hooks"
 import { useState } from "react"
 import { Action } from "../Types"
@@ -26,37 +26,41 @@ export function ActionCard({
   const { hovered, ref } = useHover()
 
   return (
-    <DraggableBaseCard
-      id={id}
-      index={index}
-      m="sm"
-      bg="primaryGreen.0"
-      pos="relative"
-      ref={ref}
-      {...props}
-    >
-      {edit && title !== "" ? (
-        <Text onClick={() => toggleEdit(!edit)}>{title}</Text>
-      ) : (
-        <TextInput
-          onBlur={() => toggleEdit(!edit)}
-          onChange={(event) => {
-            setTitle(event.currentTarget.value)
-            updateAction(storyMapId, {
-              id,
-              title: event.currentTarget.value,
-            } as Action)
-          }}
-          variant="unstyled"
-          value={title}
-          autoFocus
-          styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+    <Tooltip label={title}>
+      <DraggableBaseCard
+        id={id}
+        index={index}
+        m="sm"
+        bg="primaryGreen.0"
+        pos="relative"
+        ref={ref}
+        {...props}
+      >
+        {edit && title !== "" ? (
+          <Text onClick={() => toggleEdit(!edit)} truncate>
+            {title}
+          </Text>
+        ) : (
+          <TextInput
+            onBlur={() => toggleEdit(!edit)}
+            onChange={(event) => {
+              setTitle(event.currentTarget.value)
+              updateAction(storyMapId, {
+                id,
+                title: event.currentTarget.value,
+              } as Action)
+            }}
+            variant="unstyled"
+            value={title}
+            autoFocus
+            styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+          />
+        )}
+        <DeleteButton
+          mounted={hovered}
+          onClick={() => deleteAction(storyMapId, action.id)}
         />
-      )}
-      <DeleteButton
-        mounted={hovered}
-        onClick={() => deleteAction(storyMapId, action.id)}
-      />
-    </DraggableBaseCard>
+      </DraggableBaseCard>
+    </Tooltip>
   )
 }

--- a/project-canvas/src/components/StoryMapView/Cards/ActionCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/ActionCard.tsx
@@ -26,7 +26,7 @@ export function ActionCard({
   const { hovered, ref } = useHover()
 
   return (
-    <Tooltip label={title}>
+    <Tooltip label={title} disabled={!title}>
       <DraggableBaseCard
         id={id}
         index={index}
@@ -53,7 +53,9 @@ export function ActionCard({
             variant="unstyled"
             value={title}
             autoFocus
-            styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+            styles={{
+              input: { textAlign: "center", fontSize: "16px", color: "black" },
+            }}
           />
         )}
         <DeleteButton

--- a/project-canvas/src/components/StoryMapView/Cards/ActionCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/ActionCard.tsx
@@ -43,6 +43,7 @@ export function ActionCard({
         ) : (
           <TextInput
             onBlur={() => toggleEdit(!edit)}
+            placeholder="Action"
             onChange={(event) => {
               setTitle(event.currentTarget.value)
               updateAction(storyMapId, {

--- a/project-canvas/src/components/StoryMapView/Cards/CaseTitleCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/CaseTitleCard.tsx
@@ -20,7 +20,7 @@ export function CaseTitleCard({
   const [title, setTitle] = useState(caseColumn.title)
   const { hovered, ref } = useHover()
   return (
-    <Tooltip label={title}>
+    <Tooltip label={title} disabled={!title}>
       <BaseCard
         w="100%"
         bg="primaryBlue.0"
@@ -49,7 +49,9 @@ export function CaseTitleCard({
             variant="unstyled"
             defaultValue={title}
             autoFocus
-            styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+            styles={{
+              input: { textAlign: "center", fontSize: "16px", color: "black" },
+            }}
           />
         )}
         <DeleteButton

--- a/project-canvas/src/components/StoryMapView/Cards/CaseTitleCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/CaseTitleCard.tsx
@@ -1,4 +1,4 @@
-import { TextInput, Title } from "@mantine/core"
+import { TextInput, Title, Tooltip } from "@mantine/core"
 import { useHover } from "@mantine/hooks"
 import { useState } from "react"
 import { Case } from "../Types"
@@ -20,41 +20,43 @@ export function CaseTitleCard({
   const [title, setTitle] = useState(caseColumn.title)
   const { hovered, ref } = useHover()
   return (
-    <BaseCard
-      w="100%"
-      bg="primaryBlue.0"
-      pos="relative"
-      radius="sm"
-      m={undefined}
-      shadow={undefined}
-      p="md"
-      ref={ref}
-    >
-      {!edit && title !== "" ? (
-        <Title order={2} onClick={() => toggleEdit(!edit)}>
-          {title}
-        </Title>
-      ) : (
-        <TextInput
-          placeholder="Title"
-          onBlur={(event) => {
-            setTitle(event.currentTarget.value)
-            updateCase(storyMapId, {
-              id: caseColumn.id,
-              title: event.currentTarget.value,
-            })
-            toggleEdit(!edit)
-          }}
-          variant="unstyled"
-          defaultValue={title}
-          autoFocus
-          styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+    <Tooltip label={title}>
+      <BaseCard
+        w="100%"
+        bg="primaryBlue.0"
+        pos="relative"
+        radius="sm"
+        m={undefined}
+        shadow={undefined}
+        p="md"
+        ref={ref}
+      >
+        {!edit && title !== "" ? (
+          <Title order={2} onClick={() => toggleEdit(!edit)} truncate>
+            {title}
+          </Title>
+        ) : (
+          <TextInput
+            placeholder="Title"
+            onBlur={(event) => {
+              setTitle(event.currentTarget.value)
+              updateCase(storyMapId, {
+                id: caseColumn.id,
+                title: event.currentTarget.value,
+              })
+              toggleEdit(!edit)
+            }}
+            variant="unstyled"
+            defaultValue={title}
+            autoFocus
+            styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+          />
+        )}
+        <DeleteButton
+          mounted={hovered}
+          onClick={() => deleteCase(storyMapId, caseColumn.id)}
         />
-      )}
-      <DeleteButton
-        mounted={hovered}
-        onClick={() => deleteCase(storyMapId, caseColumn.id)}
-      />
-    </BaseCard>
+      </BaseCard>
+    </Tooltip>
   )
 }

--- a/project-canvas/src/components/StoryMapView/Cards/SubActionCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/SubActionCard.tsx
@@ -54,7 +54,9 @@ export function SubActionCard({
             variant="unstyled"
             value={title}
             autoFocus
-            styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+            styles={{
+              input: { textAlign: "center", fontSize: "16px", color: "black" },
+            }}
           />
         )}
         <DeleteButton

--- a/project-canvas/src/components/StoryMapView/Cards/SubActionCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/SubActionCard.tsx
@@ -1,4 +1,4 @@
-import { PaperProps, Text, TextInput } from "@mantine/core"
+import { PaperProps, Text, TextInput, Tooltip } from "@mantine/core"
 import { useHover, useToggle } from "@mantine/hooks"
 import { useState } from "react"
 import { SubAction } from "../Types"
@@ -26,38 +26,42 @@ export function SubActionCard({
   const { hovered, ref } = useHover()
 
   return (
-    <DraggableBaseCard
-      id={id}
-      index={index}
-      m="sm"
-      bg="white"
-      pos="relative"
-      ref={ref}
-      {...props}
-    >
-      {edit && title !== "" ? (
-        <Text onClick={() => toggleEdit()}>{title}</Text>
-      ) : (
-        <TextInput
-          onBlur={() => toggleEdit()}
-          placeholder="Title"
-          onChange={(event) => {
-            setTitle(event.currentTarget.value)
-            updateSubAction(storyMapId, {
-              id,
-              title: event.currentTarget.value,
-            })
-          }}
-          variant="unstyled"
-          value={title}
-          autoFocus
-          styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+    <Tooltip label={title}>
+      <DraggableBaseCard
+        id={id}
+        index={index}
+        m="sm"
+        bg="white"
+        pos="relative"
+        ref={ref}
+        {...props}
+      >
+        {edit && title !== "" ? (
+          <Text onClick={() => toggleEdit()} truncate>
+            {title}
+          </Text>
+        ) : (
+          <TextInput
+            onBlur={() => toggleEdit()}
+            placeholder="Title"
+            onChange={(event) => {
+              setTitle(event.currentTarget.value)
+              updateSubAction(storyMapId, {
+                id,
+                title: event.currentTarget.value,
+              })
+            }}
+            variant="unstyled"
+            value={title}
+            autoFocus
+            styles={{ input: { textAlign: "center", fontSize: "16px" } }}
+          />
+        )}
+        <DeleteButton
+          mounted={hovered}
+          onClick={() => deleteSubAction(storyMapId, subAction.id)}
         />
-      )}
-      <DeleteButton
-        mounted={hovered}
-        onClick={() => deleteSubAction(storyMapId, subAction.id)}
-      />
-    </DraggableBaseCard>
+      </DraggableBaseCard>
+    </Tooltip>
   )
 }

--- a/project-canvas/src/components/StoryMapView/Cards/SubActionCard.tsx
+++ b/project-canvas/src/components/StoryMapView/Cards/SubActionCard.tsx
@@ -26,7 +26,7 @@ export function SubActionCard({
   const { hovered, ref } = useHover()
 
   return (
-    <Tooltip label={title}>
+    <Tooltip label={title} disabled={!title}>
       <DraggableBaseCard
         id={id}
         index={index}

--- a/project-canvas/src/components/StoryMapView/Components/DeleteButton.tsx
+++ b/project-canvas/src/components/StoryMapView/Components/DeleteButton.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Transition } from "@mantine/core"
+import { ActionIcon, Transition, useMantineColorScheme } from "@mantine/core"
 import { IconTrash } from "@tabler/icons"
 import { MouseEventHandler } from "react"
 
@@ -9,6 +9,8 @@ export function DeleteButton({
   mounted: boolean
   onClick: MouseEventHandler<HTMLButtonElement>
 }) {
+  const { colorScheme } = useMantineColorScheme()
+  const dark = colorScheme === "dark"
   return (
     <Transition
       mounted={mounted}
@@ -25,7 +27,7 @@ export function DeleteButton({
           size="sm"
           variant="transparent"
           onClick={onClick}
-          style={{ ...styles, color: "black" }}
+          style={{ ...styles, color: dark ? "white" : "black" }}
         >
           <IconTrash />
         </ActionIcon>

--- a/project-canvas/src/components/StoryMapView/Level/LevelControl.tsx
+++ b/project-canvas/src/components/StoryMapView/Level/LevelControl.tsx
@@ -1,4 +1,4 @@
-import { Accordion, ActionIcon, Group, TextInput } from "@mantine/core"
+import { Accordion, ActionIcon, Group, TextInput, Tooltip } from "@mantine/core"
 import { IconTrash } from "@tabler/icons"
 import { useState } from "react"
 import { useStoryMapStore } from "../StoryMapStore"
@@ -17,26 +17,28 @@ export function LevelControl({
   return (
     <Accordion.Control>
       <Group>
-        <TextInput
-          placeholder="Title"
-          {...(edit ? { readOnly: false } : { readOnly: true })}
-          onBlur={(event) => {
-            updateLevel(storyMapId, {
-              id: level.id,
-              title: event.currentTarget.value,
-            })
-            toggleEdit(false)
-          }}
-          onClick={(event) => {
-            event.stopPropagation()
-            toggleEdit(true)
-          }}
-          variant="unstyled"
-          styles={{ input: { padding: 0 } }}
-          defaultValue={level.title}
-          autoFocus
-          size="lg"
-        />
+        <Tooltip label={level.title}>
+          <TextInput
+            placeholder="Title"
+            {...(edit ? { readOnly: false } : { readOnly: true })}
+            onBlur={(event) => {
+              updateLevel(storyMapId, {
+                id: level.id,
+                title: event.currentTarget.value,
+              })
+              toggleEdit(false)
+            }}
+            onClick={(event) => {
+              event.stopPropagation()
+              toggleEdit(true)
+            }}
+            variant="unstyled"
+            styles={{ input: { padding: 0 } }}
+            defaultValue={level.title}
+            autoFocus
+            size="lg"
+          />
+        </Tooltip>
         <ActionIcon
           color="red"
           size="sm"


### PR DESCRIPTION
StoryMap: Title cards and action cards text is now truncated in order to prevent overflow. Instead, the whole text is show above the cards via tooltip